### PR TITLE
Remove Gmail from default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Use this tool to spam a person's email
 
 <b> Use this tool for educational purpose only !! </b>
 
-<h3> Note : Enable Less Secure Access on ur gmail account used to send emails before launching this tool </h3>
+<h3> WARNING: This tool is not longer compatible with gmail accounts as attacker</h3>
 
-[You can enable it there](https://myaccount.google.com/lesssecureapps)
 
 Usage for Python 2 : 
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Use this tool to spam a person's email
 
 Usage for Python 2 : 
 ```bash
-$ git clone https://github.com/mohinparamasivam/Email_Bomber.git
-$ cd Email_Bomber
+$ git clone https://github.com/mohinparamasivam/Email-Bomber.git
+$ cd Email-Bomber
 $ python2 emailbomber.py
 ```
 
 </br>Usage for Python 3 : 
 ```bash
-$ git clone https://github.com/mohinparamasivam/Email_Bomber.git
-$ cd Email_Bomber
+$ git clone https://github.com/mohinparamasivam/Email-Bomber.git
+$ cd Email-Bomber
 $ python3 emailbomber3.py
 ```
 

--- a/emailbomber3.py
+++ b/emailbomber3.py
@@ -31,20 +31,9 @@ passwd = getpass('\nAttacker Email Password : ')
 to = input('\nVictim Email Address :')
 total = input('\nNumber of send : ')
 body = input('\nMessage : ')
-Cserver = input('\nCustom smtp server (leave blank to use gmail): ')
+smtp_server = input('\nCustom smtp server: ')
+port = int(input('Custom smtp port (leave blank to use defaul port): '))
 
-if not Cserver == '':
-    defaulconf = False
-    smtp_server = Cserver
-    Cport = input('Custom smtp port (leave blank to use defaul port): ')
-    if not Cport == '':
-        port = int(Cport)
-    else:
-        port = 587
-else:
-    smtp_server = 'smtp.gmail.com'
-    port = 587
-    defaultconf = True
 
 try:
     server = smtplib.SMTP(smtp_server, port)
@@ -65,10 +54,5 @@ except KeyboardInterrupt:
     print('[-] Canceled')
     sys.exit()
 except smtplib.SMTPAuthenticationError:
-    if defaulconf:
-        print('[!] The username or password you entered is incorrect')
-        print('[!] OR')
-        print('[!] You forget to enable less secure access on your google account')
-    else:
-        print('\n[!] The username, password or custom STMP server/port you entered is incorrect.')
+    print('\n[!] The username, password or custom STMP server/port you entered is incorrect.')
     sys.exit()

--- a/emailbomber3.py
+++ b/emailbomber3.py
@@ -32,8 +32,12 @@ to = input('\nVictim Email Address :')
 total = input('\nNumber of send : ')
 body = input('\nMessage : ')
 smtp_server = input('\nCustom smtp server: ')
-port = int(input('Custom smtp port (leave blank to use defaul port): '))
+port = input('Custom smtp port (leave blank to use port 587): ')
 
+if not port == '':
+    port = int(port)
+else:
+    port = 587
 
 try:
     server = smtplib.SMTP(smtp_server, port)


### PR DESCRIPTION
Gmail not longer supports less secure access, this is necessary for the tool to work properly.

This PR removes gmail as default from `emailbomber3.py` and warns about it in the readme